### PR TITLE
Implement Mutex Hat Prediction

### DIFF
--- a/tools/checklocks/checklocks.go
+++ b/tools/checklocks/checklocks.go
@@ -95,7 +95,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	})
 	pc.forAllTypes(func(ts *ast.TypeSpec) {
 		if ss, ok := ts.Type.(*ast.StructType); ok {
-			pc.inferLockGuardFacts(ts, ss)
+			pc.exportHatGuards(ts, ss)
 		}
 	})
 	pc.forAllTypes(func(ts *ast.TypeSpec) {

--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -16,5 +16,6 @@ go_library(
         "parameters.go",
         "return.go",
         "test.go",
+        "infer.go",
     ],
 )

--- a/tools/checklocks/test/infer.go
+++ b/tools/checklocks/test/infer.go
@@ -14,4 +14,17 @@ func testGuessedNoLockAccessValid(tc *guessedGuardNoGuardStruct) {
 	tc.unguardedField = 1
 }
 
+func testGuessedAndAnnotatedValid(tc *guessedAndAnnotatedGuardStruct) {
+	tc.mu.Lock()
+	tc.guardedField = 1
+	tc.annotatedGuardField = 2
+	tc.mu.Unlock()
+	tc.unguardedField = 3
+}
+
+func testGuessedAndAnnotatedInvalid(tc *guessedAndAnnotatedGuardStruct) {
+	tc.guardedField = 1        // +checklocksfail
+	tc.annotatedGuardField = 2 // +checkslockfail
+}
+
 // TODO(jamesyou): more tests

--- a/tools/checklocks/test/test.go
+++ b/tools/checklocks/test/test.go
@@ -25,7 +25,8 @@ import (
 type oneGuardStruct struct {
 	mu sync.Mutex
 	// +checklocks:mu
-	guardedField   int
+	guardedField int
+
 	unguardedField int
 }
 
@@ -73,6 +74,15 @@ type guessedGuardNoGuardStruct struct {
 	guardedField int
 
 	unguardedField int
+}
+
+type guessedAndAnnotatedGuardStruct struct {
+	mu           sync.Mutex
+	guardedField int
+
+	// +checklocks:mu
+	annotatedGuardField int
+	unguardedField      int
 }
 
 // TODO(jamesyou): add more structs to be inferred


### PR DESCRIPTION
This CL implements mutex hat prediction for lock annotations
on `struct` types. The prediction logic is currently limited
to structs where a field follows a mutex with only other
fields or doc lines in between, with no line breaks.

For example:

```Go
type Foo struct {
    mu            Mutex // mutex hat start
    guardedField1 int
    // Doc
    guardedField2 int   // mutex hat end

    unguardedField int
}
```