### PR TITLE
Instrument checklocks to collect stats

### DIFF
--- a/tools/benchlocks/BUILD
+++ b/tools/benchlocks/BUILD
@@ -1,0 +1,15 @@
+load("//tools:defs.bzl", "go_library")
+
+package(licenses = ["notice"])
+
+go_library(
+    name = "benchlocks",
+    srcs = ["benchlocks.go"],
+    nogo = False,
+    visibility = ["//tools/nogo:__subpackages__"],
+    deps = [
+        "@org_golang_x_tools//go/analysis:go_default_library",
+        "@org_golang_x_tools//go/analysis/passes/buildssa:go_default_library",
+        "@org_golang_x_tools//go/ssa:go_default_library",
+    ],
+)

--- a/tools/benchlocks/benchlocks.go
+++ b/tools/benchlocks/benchlocks.go
@@ -1,0 +1,73 @@
+package benchlocks
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/tools/go/analysis"
+	"gvisor.dev/gvisor/tools/checklocks"
+)
+
+type Stats map[string]string
+
+type StatsPass struct {
+	pass *analysis.Pass
+}
+
+var Analyzer = &analysis.Analyzer{
+	Name:      "benchlocks",
+	Doc:       "Processes and outputs stats from the checklocks analyzer",
+	Run:       run,
+	Requires:  []*analysis.Analyzer{checklocks.Analyzer},
+	FactTypes: []analysis.Fact{},
+}
+
+func (sp *StatsPass) collectChecklocksStats(pgf *checklocks.PkgPerfFacts) Stats {
+	var (
+		total   time.Duration
+		fn      string
+		slowest time.Duration
+	)
+	for f, time := range pgf.FunctionCheckTime {
+		total += time
+		if time > slowest {
+			fn, slowest = f, time
+		}
+	}
+	stats := make(map[string]string)
+	stats["total_time"] = fmt.Sprintf("%d ms", total.Milliseconds())
+	stats["slowest_function"] = fn
+	stats["slowest_time"] = fmt.Sprintf("%d us", total.Microseconds())
+
+	var totalErrors int
+	problematicFiles := make(map[string]struct{})
+	for pos, count := range pgf.ErrorSiteCount {
+		position := sp.pass.Fset.Position(pos)
+		problematicFiles[position.Filename] = struct{}{}
+		totalErrors += count
+	}
+
+	stats["error_files"] = fmt.Sprint(problematicFiles)
+	stats["total_errors"] = fmt.Sprint(totalErrors)
+
+	return stats
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	if !checklocks.Benchmark {
+		return nil, nil
+	}
+
+	sp := StatsPass{pass}
+
+	results := sp.pass.ResultOf[checklocks.Analyzer].(*checklocks.PkgPerfFacts)
+	stats := sp.collectChecklocksStats(results)
+
+	for name, data := range stats {
+		pass.Report(analysis.Diagnostic{
+			Message: fmt.Sprintf("%s-%s=%s", pass.Pkg.Name(), name, data),
+		})
+	}
+
+	return nil, nil
+}

--- a/tools/benchlocks/benchlocks.go
+++ b/tools/benchlocks/benchlocks.go
@@ -23,7 +23,7 @@ var Analyzer = &analysis.Analyzer{
 	Requires: []*analysis.Analyzer{checklocks.Analyzer},
 }
 
-func (sp *statsPass) collectChecklocksStats(ppd *checklocks.PkgPerfData) Stats {
+func (sp *statsPass) collect(ppd *checklocks.PkgPerfData) Stats {
 	var (
 		total   time.Duration
 		slowest string
@@ -62,7 +62,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, nil
 	}
 
-	stats := sp.collectChecklocksStats(ppd)
+	stats := sp.collect(ppd)
 
 	for name, data := range stats {
 		pass.Report(analysis.Diagnostic{

--- a/tools/checklocks/annotations.go
+++ b/tools/checklocks/annotations.go
@@ -87,7 +87,7 @@ func (pc *passContext) maybeFail(pos token.Pos, fmtStr string, args ...interface
 	if _, ok := pc.exemptions[pc.positionKey(pos)]; ok {
 		return // Ignored, not counted.
 	}
-	pc.perfdata.ErrorSiteCount[pos]++
+	pc.perf.ErrorSiteCount[pos]++
 	pc.pass.Reportf(pos, fmtStr, args...)
 }
 

--- a/tools/checklocks/annotations.go
+++ b/tools/checklocks/annotations.go
@@ -87,7 +87,9 @@ func (pc *passContext) maybeFail(pos token.Pos, fmtStr string, args ...interface
 	if _, ok := pc.exemptions[pc.positionKey(pos)]; ok {
 		return // Ignored, not counted.
 	}
-	pc.perf.ErrorSiteCount[pos]++
+	if pc.perf != nil {
+		pc.perf.ErrorSiteCount[pos]++
+	}
 	pc.pass.Reportf(pos, fmtStr, args...)
 }
 

--- a/tools/checklocks/annotations.go
+++ b/tools/checklocks/annotations.go
@@ -78,19 +78,6 @@ func (pc *passContext) addForce(pos token.Pos) {
 	pc.forced[pc.positionKey(pos)] = struct{}{}
 }
 
-// recordErrorSite saves an error at a Pos for stats collection.
-func (pc *passContext) recordErrorSite(pos token.Pos) {
-	var pgf PkgPerfFacts
-	pc.pass.ImportPackageFact(pc.pass.Pkg, &pgf)
-
-	if pgf.ErrorSiteCount == nil {
-		pgf.ErrorSiteCount = make(map[token.Pos]int)
-	}
-	pgf.ErrorSiteCount[pos]++
-
-	pc.pass.ExportPackageFact(&pgf)
-}
-
 // maybeFail checks a potential failure against a specific failure map.
 func (pc *passContext) maybeFail(pos token.Pos, fmtStr string, args ...interface{}) {
 	if fd, ok := pc.failures[pc.positionKey(pos)]; ok {
@@ -100,7 +87,7 @@ func (pc *passContext) maybeFail(pos token.Pos, fmtStr string, args ...interface
 	if _, ok := pc.exemptions[pc.positionKey(pos)]; ok {
 		return // Ignored, not counted.
 	}
-	pc.recordErrorSite(pos)
+	pc.perfdata.ErrorSiteCount[pos]++
 	pc.pass.Reportf(pos, fmtStr, args...)
 }
 

--- a/tools/checklocks/checklocks.go
+++ b/tools/checklocks/checklocks.go
@@ -54,9 +54,6 @@ type PkgPerfData struct {
 	// FunctionCheckTime is the time spent analyzing a function. The data
 	// is saved as time.Duration as the unit of time can be decided after processing.
 	FunctionCheckTime map[string]time.Duration
-
-	// start is a temporary variable used in computing function check times.
-	start time.Time
 }
 
 // passContext is a pass with additional expected failures.
@@ -169,15 +166,16 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			continue
 		}
 
+		var start time.Time
 		if Benchmark {
-			pc.perf.start = time.Now()
+			start = time.Now()
 		}
 
 		// Check the basic blocks in the function.
 		pc.checkFunction(nil, fn, &lff, nil, false /* force */)
 
 		if Benchmark {
-			pc.perf.FunctionCheckTime[fn.Name()] = time.Since(pc.perf.start)
+			pc.perf.FunctionCheckTime[fn.Name()] = time.Since(start)
 		}
 	}
 	for _, fn := range state.SrcFuncs {

--- a/tools/checklocks/checklocks.go
+++ b/tools/checklocks/checklocks.go
@@ -167,14 +167,14 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		var start time.Time
-		if Benchmark {
+		if pc.perf != nil {
 			start = time.Now()
 		}
 
 		// Check the basic blocks in the function.
 		pc.checkFunction(nil, fn, &lff, nil, false /* force */)
 
-		if Benchmark {
+		if pc.perf != nil {
 			pc.perf.FunctionCheckTime[fn.Name()] = time.Since(start)
 		}
 	}
@@ -191,9 +191,5 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	// Check for expected failures.
 	pc.checkFailures()
 
-	if Benchmark {
-		return pc.perf, nil
-	}
-
-	return nil, nil
+	return pc.perf, nil
 }

--- a/tools/checklocks/facts.go
+++ b/tools/checklocks/facts.go
@@ -21,7 +21,6 @@ import (
 	"go/types"
 	"regexp"
 	"strings"
-	"time"
 
 	"golang.org/x/tools/go/ssa"
 )
@@ -687,19 +686,3 @@ func (pc *passContext) exportFunctionFacts(d *ast.FuncDecl) {
 		pc.pass.ExportObjectFact(funcObj, &lff)
 	}
 }
-
-// PKfPerfFacts stores revelant analysis stats for processing in benchlocks.
-type PkgPerfFacts struct {
-	// ErrorSiteCount records the total number of errors reported at a token.Pos
-	ErrorSiteCount map[token.Pos]int
-
-	// BasicBlocksVisits stores the average number of visits made per basic block
-	// in the control flow graph of a function.
-	BasicBlockVisits map[string]int
-
-	// FunctionCheckTime is the time spent analyzing a function. The data
-	// is saved as time.Duration as the unit of time can be decided after processing
-	FunctionCheckTime map[string]time.Duration
-}
-
-func (*PkgPerfFacts) AFact() {}

--- a/tools/checklocks/facts.go
+++ b/tools/checklocks/facts.go
@@ -21,6 +21,7 @@ import (
 	"go/types"
 	"regexp"
 	"strings"
+	"time"
 
 	"golang.org/x/tools/go/ssa"
 )
@@ -686,3 +687,19 @@ func (pc *passContext) exportFunctionFacts(d *ast.FuncDecl) {
 		pc.pass.ExportObjectFact(funcObj, &lff)
 	}
 }
+
+// PKfPerfFacts stores revelant analysis stats for processing in benchlocks.
+type PkgPerfFacts struct {
+	// ErrorSiteCount records the total number of errors reported at a token.Pos
+	ErrorSiteCount map[token.Pos]int
+
+	// BasicBlocksVisits stores the average number of visits made per basic block
+	// in the control flow graph of a function.
+	BasicBlockVisits map[string]int
+
+	// FunctionCheckTime is the time spent analyzing a function. The data
+	// is saved as time.Duration as the unit of time can be decided after processing
+	FunctionCheckTime map[string]time.Duration
+}
+
+func (*PkgPerfFacts) AFact() {}


### PR DESCRIPTION
This CL implements instrumentation inside the checklocks
analyzer to collect the following information:

- Error sites and frequency
- Function analysis wallclock time

This CL also implements the benchlocks analyzer,
which processes the collected stats and outputs them
as diagnostics.