### PR TITLE
Merge checklocks changes from gVisor upstream

### DIFF
--- a/pkg/sentry/fsimpl/gofer/filesystem.go
+++ b/pkg/sentry/fsimpl/gofer/filesystem.go
@@ -130,7 +130,7 @@ func putDentrySlice(ds *[]*dentry) {
 // but dentry slices are allocated lazily, and it's much easier to say "defer
 // fs.renameMuRUnlockAndCheckCaching(&ds)" than "defer func() {
 // fs.renameMuRUnlockAndCheckCaching(ds) }()" to work around this.
-// +checklocksrelease:fs.renameMu
+// +checklocksreleaseread:fs.renameMu
 func (fs *filesystem) renameMuRUnlockAndCheckCaching(ctx context.Context, dsp **[]*dentry) {
 	fs.renameMu.RUnlock()
 	if *dsp == nil {

--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -86,7 +86,7 @@ func putDentrySlice(ds *[]*dentry) {
 // fs.renameMuRUnlockAndCheckDrop(&ds)" than "defer func() {
 // fs.renameMuRUnlockAndCheckDrop(ds) }()" to work around this.
 //
-// +checklocksrelease:fs.renameMu
+// +checklocksreleaseread:fs.renameMu
 func (fs *filesystem) renameMuRUnlockAndCheckDrop(ctx context.Context, dsp **[]*dentry) {
 	fs.renameMu.RUnlock()
 	if *dsp == nil {

--- a/pkg/sentry/fsimpl/verity/filesystem.go
+++ b/pkg/sentry/fsimpl/verity/filesystem.go
@@ -74,7 +74,7 @@ func putDentrySlice(ds *[]*dentry) {
 // but dentry slices are allocated lazily, and it's much easier to say "defer
 // fs.renameMuRUnlockAndCheckCaching(&ds)" than "defer func() {
 // fs.renameMuRUnlockAndCheckCaching(ds) }()" to work around this.
-// +checklocksrelease:fs.renameMu
+// +checklocksreleaseread:fs.renameMu
 func (fs *filesystem) renameMuRUnlockAndCheckCaching(ctx context.Context, ds **[]*dentry) {
 	fs.renameMu.RUnlock()
 	if *ds == nil {

--- a/pkg/tcpip/stack/nic.go
+++ b/pkg/tcpip/stack/nic.go
@@ -41,17 +41,6 @@ func (l *linkResolver) confirmReachable(addr tcpip.Address) {
 
 var _ NetworkInterface = (*nic)(nil)
 
-// TODO(https://gvisor.dev/issue/6558): Use an anonymous struct in nic for this
-// once copylocks supports anonymous structs.
-type packetEPs struct {
-	mu sync.RWMutex
-
-	// eps is protected by the mutex, but the values contained in it are not.
-	//
-	// +checklocks:mu
-	eps map[tcpip.NetworkProtocolNumber]*packetEndpointList
-}
-
 // nic represents a "network interface card" to which the networking stack is
 // attached.
 type nic struct {
@@ -85,7 +74,14 @@ type nic struct {
 		promiscuous bool
 	}
 
-	packetEPs packetEPs
+	packetEPs struct {
+		mu sync.RWMutex
+
+		// eps is protected by the mutex, but the values contained in it are not.
+		//
+		// +checklocks:mu
+		eps map[tcpip.NetworkProtocolNumber]*packetEndpointList
+	}
 }
 
 // makeNICStats initializes the NIC statistics and associates them to the global

--- a/pkg/tcpip/stack/transport_demuxer.go
+++ b/pkg/tcpip/stack/transport_demuxer.go
@@ -69,7 +69,7 @@ func (eps *transportEndpoints) transportEndpoints() []TransportEndpoint {
 // descending order of match quality. If a call to yield returns false,
 // iterEndpointsLocked stops iteration and returns immediately.
 //
-// Preconditions: eps.mu must be locked.
+// +checklocksread:eps.mu
 func (eps *transportEndpoints) iterEndpointsLocked(id TransportEndpointID, yield func(*endpointsByNIC) bool) {
 	// Try to find a match with the id as provided.
 	if ep, ok := eps.endpoints[id]; ok {
@@ -110,7 +110,7 @@ func (eps *transportEndpoints) iterEndpointsLocked(id TransportEndpointID, yield
 // findAllEndpointsLocked returns all endpointsByNIC in eps that match id, in
 // descending order of match quality.
 //
-// Preconditions: eps.mu must be locked.
+// +checklocksread:eps.mu
 func (eps *transportEndpoints) findAllEndpointsLocked(id TransportEndpointID) []*endpointsByNIC {
 	var matchedEPs []*endpointsByNIC
 	eps.iterEndpointsLocked(id, func(ep *endpointsByNIC) bool {
@@ -122,7 +122,7 @@ func (eps *transportEndpoints) findAllEndpointsLocked(id TransportEndpointID) []
 
 // findEndpointLocked returns the endpoint that most closely matches the given id.
 //
-// Preconditions: eps.mu must be locked.
+// +checklocksread:eps.mu
 func (eps *transportEndpoints) findEndpointLocked(id TransportEndpointID) *endpointsByNIC {
 	var matchedEP *endpointsByNIC
 	eps.iterEndpointsLocked(id, func(ep *endpointsByNIC) bool {

--- a/pkg/tcpip/transport/icmp/endpoint.go
+++ b/pkg/tcpip/transport/icmp/endpoint.go
@@ -213,11 +213,11 @@ func (e *endpoint) Read(dst io.Writer, opts tcpip.ReadOptions) (tcpip.ReadResult
 // reacquire the mutex in exclusive mode.
 //
 // Returns true for retry if preparation should be retried.
-// +checklocks:e.mu
-func (e *endpoint) prepareForWrite(to *tcpip.FullAddress) (retry bool, err tcpip.Error) {
-	switch e.state {
-	case stateInitial:
-	case stateConnected:
+// +checklocksread:e.mu
+func (e *endpoint) prepareForWriteInner(to *tcpip.FullAddress) (retry bool, err tcpip.Error) {
+	switch e.net.State() {
+	case transport.DatagramEndpointStateInitial:
+	case transport.DatagramEndpointStateConnected:
 		return false, nil
 
 	case stateBound:

--- a/pkg/tcpip/transport/internal/network/endpoint.go
+++ b/pkg/tcpip/transport/internal/network/endpoint.go
@@ -303,8 +303,10 @@ func (e *Endpoint) Disconnect() {
 // connectRoute establishes a route to the specified interface or the
 // configured multicast interface if no interface is specified and the
 // specified address is a multicast address.
-func (e *Endpoint) connectRoute(nicID tcpip.NICID, addr tcpip.FullAddress, netProto tcpip.NetworkProtocolNumber) (*stack.Route, tcpip.NICID, tcpip.Error) {
-	localAddr := e.info.ID.LocalAddress
+//
+// +checklocksread:e.mu
+func (e *Endpoint) connectRouteRLocked(nicID tcpip.NICID, addr tcpip.FullAddress, netProto tcpip.NetworkProtocolNumber) (*stack.Route, tcpip.NICID, tcpip.Error) {
+	localAddr := e.Info().ID.LocalAddress
 	if e.isBroadcastOrMulticast(nicID, netProto, localAddr) {
 		// A packet can only originate from a unicast address (i.e., an interface).
 		localAddr = ""

--- a/pkg/tcpip/transport/udp/endpoint.go
+++ b/pkg/tcpip/transport/udp/endpoint.go
@@ -275,7 +275,7 @@ func (e *endpoint) Read(dst io.Writer, opts tcpip.ReadOptions) (tcpip.ReadResult
 // reacquire the mutex in exclusive mode.
 //
 // Returns true for retry if preparation should be retried.
-// +checklocks:e.mu
+// +checklocksread:e.mu
 func (e *endpoint) prepareForWriteInner(to *tcpip.FullAddress) (retry bool, err tcpip.Error) {
 	switch e.net.State() {
 	case transport.DatagramEndpointStateInitial:

--- a/tools/checklocks/README.md
+++ b/tools/checklocks/README.md
@@ -1,6 +1,6 @@
 # CheckLocks Analyzer
 
-<!--* freshness: { owner: 'gvisor-eng' reviewed: '2021-03-21' } *-->
+<!--* freshness: { owner: 'gvisor-eng' reviewed: '2021-10-15' } *-->
 
 Checklocks is an analyzer for lock and atomic constraints. The analyzer relies
 on explicit annotations to identify fields that should be checked for access.
@@ -99,29 +99,6 @@ func abc() {
 ```
 
 ### Explicitly Not Supported
-
-1.  Checking for embedded mutexes as sync.Locker rather than directly as
-    'sync.Mutex'. In other words, the checker will not track mutex Lock and
-    Unlock() methods where the mutex is behind an interface dispatch.
-
-An example that we won't handle is shown below (this in fact will fail to
-build):
-
-```go
-type A struct {
-  mu sync.Locker
-
-  // +checklocks:mu
-  x int
-}
-
-func abc() {
-   mu sync.Mutex
-   a := A{mu: &mu}
-   a.x = 1 // This won't be flagged by copylocks checker.
-}
-
-```
 
 1.  The checker will not support guards on anything other than the cases
     described above. For example, global mutexes cannot be referred to by

--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -183,8 +183,8 @@ type instructionWithReferrers interface {
 // checkFieldAccess checks the validity of a field access.
 //
 // This also enforces atomicity constraints for fields that must be accessed
-// atomically. The parameter isWrite indicates whether this field is used
-// downstream for a write operation.
+// atomically. The parameter isWrite indicates whether this field is used for
+// a write operation.
 func (pc *passContext) checkFieldAccess(inst instructionWithReferrers, structObj ssa.Value, field int, ls *lockState, isWrite bool) {
 	var (
 		lff         lockFieldFacts
@@ -200,13 +200,14 @@ func (pc *passContext) checkFieldAccess(inst instructionWithReferrers, structObj
 	for guardName, fl := range lgf.GuardedBy {
 		guardsFound++
 		r := fl.resolve(structObj)
-		if _, ok := ls.isHeld(r); ok {
+		if _, ok := ls.isHeld(r, isWrite); ok {
 			guardsHeld++
 			continue
 		}
 		if _, ok := pc.forced[pc.positionKey(inst.Pos())]; ok {
-			// Mark this as locked, since it has been forced.
-			ls.lockField(r)
+			// Mark this as locked, since it has been forced. All
+			// forces are treated as an exclusive lock.
+			ls.lockField(r, true /* exclusive */)
 			guardsHeld++
 			continue
 		}
@@ -301,7 +302,7 @@ func (pc *passContext) postFunctionCallUpdate(call callCommon, lff *lockFunction
 			continue
 		}
 		r := fg.resolveCall(call.Common().Args, call.Value())
-		if s, ok := ls.unlockField(r); !ok {
+		if s, ok := ls.unlockField(r, fg.Exclusive); !ok {
 			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
 				pc.maybeFail(call.Pos(), "attempt to release %s (%s), but not held (locks: %s)", fieldName, s, ls.String())
 			}
@@ -315,12 +316,20 @@ func (pc *passContext) postFunctionCallUpdate(call callCommon, lff *lockFunction
 		}
 		// Acquire the lock per the annotation.
 		r := fg.resolveCall(call.Common().Args, call.Value())
-		if s, ok := ls.lockField(r); !ok {
+		if s, ok := ls.lockField(r, fg.Exclusive); !ok {
 			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
 				pc.maybeFail(call.Pos(), "attempt to acquire %s (%s), but already held (locks: %s)", fieldName, s, ls.String())
 			}
 		}
 	}
+}
+
+// exclusiveStr returns a string describing exclusive requirements.
+func exclusiveStr(exclusive bool) string {
+	if exclusive {
+		return "exclusively"
+	}
+	return "non-exclusively"
 }
 
 // checkFunctionCall checks preconditions for function calls, and tracks the
@@ -332,12 +341,12 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *ssa.Function, lff 
 	// Check all guards required are held.
 	for fieldName, fg := range lff.HeldOnEntry {
 		r := fg.resolveCall(call.Common().Args, call.Value())
-		if s, ok := ls.isHeld(r); !ok {
+		if s, ok := ls.isHeld(r, fg.Exclusive); !ok {
 			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
-				pc.maybeFail(call.Pos(), "must hold %s (%s) to call %s, but not held (locks: %s)", fieldName, s, fn.Name(), ls.String())
+				pc.maybeFail(call.Pos(), "must hold %s %s (%s) to call %s, but not held (locks: %s)", fieldName, exclusiveStr(fg.Exclusive), s, fn.Name(), ls.String())
 			} else {
 				// Force the lock to be acquired.
-				ls.lockField(r)
+				ls.lockField(r, fg.Exclusive)
 			}
 		}
 	}
@@ -348,19 +357,33 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *ssa.Function, lff 
 	// Check if it's a method dispatch for something in the sync package.
 	// See: https://godoc.org/golang.org/x/tools/go/ssa#Function
 	if fn.Package() != nil && fn.Package().Pkg.Name() == "sync" && fn.Signature.Recv() != nil {
+		isExclusive := false
 		switch fn.Name() {
-		case "Lock", "RLock":
-			if s, ok := ls.lockField(resolvedValue{value: call.Common().Args[0], valid: true}); !ok {
+		case "Lock":
+			isExclusive = true
+			fallthrough
+		case "RLock":
+			if s, ok := ls.lockField(resolvedValue{value: call.Common().Args[0], valid: true}, isExclusive); !ok {
 				if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
 					// Double locking a mutex that is already locked.
 					pc.maybeFail(call.Pos(), "%s already locked (locks: %s)", s, ls.String())
 				}
 			}
-		case "Unlock", "RUnlock":
-			if s, ok := ls.unlockField(resolvedValue{value: call.Common().Args[0], valid: true}); !ok {
+		case "Unlock":
+			isExclusive = true
+			fallthrough
+		case "RUnlock":
+			if s, ok := ls.unlockField(resolvedValue{value: call.Common().Args[0], valid: true}, isExclusive); !ok {
 				if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
 					// Unlocking something that is already unlocked.
-					pc.maybeFail(call.Pos(), "%s already unlocked (locks: %s)", s, ls.String())
+					pc.maybeFail(call.Pos(), "%s already unlocked or locked differently (locks: %s)", s, ls.String())
+				}
+			}
+		case "DowngradeLock":
+			if s, ok := ls.downgradeField(resolvedValue{value: call.Common().Args[0], valid: true}); !ok {
+				if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
+					// Downgrading something that may not be downgraded.
+					pc.maybeFail(call.Pos(), "%s already unlocked or not exclusive (locks: %s)", s, ls.String())
 				}
 			}
 		}
@@ -514,13 +537,13 @@ func (pc *passContext) checkBasicBlock(fn *ssa.Function, block *ssa.BasicBlock, 
 			// Validate held locks.
 			for fieldName, fg := range lff.HeldOnExit {
 				r := fg.resolveStatic(fn, rv)
-				if s, ok := rls.isHeld(r); !ok {
+				if s, ok := rls.isHeld(r, fg.Exclusive); !ok {
 					if _, ok := pc.forced[pc.positionKey(rv.Pos())]; !ok {
-						pc.maybeFail(rv.Pos(), "lock %s (%s) not held (locks: %s)", fieldName, s, rls.String())
+						pc.maybeFail(rv.Pos(), "lock %s (%s) not held %s (locks: %s)", fieldName, s, exclusiveStr(fg.Exclusive), rls.String())
 						failed = true
 					} else {
 						// Force the lock to be acquired.
-						rls.lockField(r)
+						rls.lockField(r, fg.Exclusive)
 					}
 				}
 			}
@@ -619,11 +642,11 @@ func (pc *passContext) checkFunction(call callCommon, fn *ssa.Function, lff *loc
 		// The first is the method object itself so we skip that when looking
 		// for receiver/function parameters.
 		r := fg.resolveStatic(fn, call.Value())
-		if s, ok := ls.lockField(r); !ok {
+		if s, ok := ls.lockField(r, fg.Exclusive); !ok {
 			// This can only happen if the same value is declared
 			// multiple times, and should be caught by the earlier
 			// fact scanning. Keep it here as a sanity check.
-			pc.maybeFail(fn.Pos(), "lock %s (%s) acquired multiple times (locks: %s)", fieldName, s, ls.String())
+			pc.maybeFail(fn.Pos(), "lock %s (%s) acquired multiple times or differently (locks: %s)", fieldName, s, ls.String())
 		}
 	}
 

--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -183,8 +183,11 @@ type instructionWithReferrers interface {
 // checkFieldAccess checks the validity of a field access.
 //
 // This also enforces atomicity constraints for fields that must be accessed
-// atomically. The parameter isWrite indicates whether this field is used for
-// a write operation.
+// atomically. The parameter isWrite indicates whether this field is used
+// downstream for a write operation.
+//
+// Note that this function is not called if lff.Ignore is true, since it cannot
+// discover any local anonymous functions or closures.
 func (pc *passContext) checkFieldAccess(inst instructionWithReferrers, structObj ssa.Value, field int, ls *lockState, isWrite bool) {
 	var (
 		lff         lockFieldFacts
@@ -200,7 +203,8 @@ func (pc *passContext) checkFieldAccess(inst instructionWithReferrers, structObj
 	for guardName, fl := range lgf.GuardedBy {
 		guardsFound++
 		r := fl.resolve(structObj)
-		if _, ok := ls.isHeld(r, isWrite); ok {
+		s, ok := ls.isHeld(r, isWrite)
+		if ok {
 			guardsHeld++
 			continue
 		}
@@ -218,7 +222,7 @@ func (pc *passContext) checkFieldAccess(inst instructionWithReferrers, structObj
 		// true for this case, so we require it to be read-only.
 		if lgf.AtomicDisposition != atomicRequired {
 			// There is no force key, no atomic access and no lock held.
-			pc.maybeFail(inst.Pos(), "invalid field access, %s must be locked when accessing %s (locks: %s)", guardName, fieldObj.Name(), ls.String())
+			pc.maybeFail(inst.Pos(), "invalid field access, must hold %s (%s) when accessing %s (locks: %s)", guardName, s, fieldObj.Name(), ls.String())
 		}
 	}
 
@@ -247,10 +251,19 @@ func (pc *passContext) checkFieldAccess(inst instructionWithReferrers, structObj
 	}
 }
 
-func (pc *passContext) checkCall(call callCommon, ls *lockState) {
+func (pc *passContext) checkCall(call callCommon, lff *lockFunctionFacts, ls *lockState) {
 	// See: https://godoc.org/golang.org/x/tools/go/ssa#CallCommon
 	//
-	// 1. "call" mode: when Method is nil (!IsInvoke), a CallCommon represents an ordinary
+	// "invoke" mode: Method is non-nil, and Value is the underlying value.
+	if fn := call.Common().Method; fn != nil {
+		var nlff lockFunctionFacts
+		pc.pass.ImportObjectFact(fn, &nlff)
+		nlff.Ignore = nlff.Ignore || lff.Ignore // Inherit ignore.
+		pc.checkFunctionCall(call, fn, &nlff, ls)
+		return
+	}
+
+	// "call" mode: when Method is nil (!IsInvoke), a CallCommon represents an ordinary
 	//  function call of the value in Value, which may be a *Builtin, a *Function or any
 	//  other value of kind 'func'.
 	//
@@ -269,10 +282,13 @@ func (pc *passContext) checkCall(call callCommon, ls *lockState) {
 	//     function call.
 	switch fn := call.Common().Value.(type) {
 	case *ssa.Function:
-		var lff lockFunctionFacts
-		if fn.Object() != nil {
-			pc.pass.ImportObjectFact(fn.Object(), &lff)
-			pc.checkFunctionCall(call, fn, &lff, ls)
+		nlff := lockFunctionFacts{
+			Ignore: lff.Ignore, // Inherit ignore.
+		}
+		if obj := fn.Object(); obj != nil {
+			pc.pass.ImportObjectFact(obj, &nlff)
+			nlff.Ignore = nlff.Ignore || lff.Ignore // See above.
+			pc.checkFunctionCall(call, obj.(*types.Func), &nlff, ls)
 		} else {
 			// Anonymous functions have no facts, and cannot be
 			// annotated.  We don't check for violations using the
@@ -282,28 +298,31 @@ func (pc *passContext) checkCall(call callCommon, ls *lockState) {
 			for i, arg := range call.Common().Args {
 				fnls.store(fn.Params[i], arg)
 			}
-			pc.checkFunction(call, fn, &lff, fnls, true /* force */)
+			pc.checkFunction(call, fn, &nlff, fnls, true /* force */)
 		}
 	case *ssa.MakeClosure:
 		// Note that creating and then invoking closures locally is
 		// allowed, but analysis of passing closures is done when
 		// checking individual instructions.
-		pc.checkClosure(call, fn, ls)
+		pc.checkClosure(call, fn, lff, ls)
 	default:
 		return
 	}
 }
 
 // postFunctionCallUpdate updates all conditions.
-func (pc *passContext) postFunctionCallUpdate(call callCommon, lff *lockFunctionFacts, ls *lockState) {
+func (pc *passContext) postFunctionCallUpdate(call callCommon, lff *lockFunctionFacts, ls *lockState, aliases bool) {
 	// Release all locks not still held.
 	for fieldName, fg := range lff.HeldOnEntry {
 		if _, ok := lff.HeldOnExit[fieldName]; ok {
 			continue
 		}
+		if fg.IsAlias && !aliases {
+			continue
+		}
 		r := fg.resolveCall(call.Common().Args, call.Value())
 		if s, ok := ls.unlockField(r, fg.Exclusive); !ok {
-			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
+			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok && !lff.Ignore {
 				pc.maybeFail(call.Pos(), "attempt to release %s (%s), but not held (locks: %s)", fieldName, s, ls.String())
 			}
 		}
@@ -314,10 +333,13 @@ func (pc *passContext) postFunctionCallUpdate(call callCommon, lff *lockFunction
 		if _, ok := lff.HeldOnEntry[fieldName]; ok {
 			continue
 		}
+		if fg.IsAlias && !aliases {
+			continue
+		}
 		// Acquire the lock per the annotation.
 		r := fg.resolveCall(call.Common().Args, call.Value())
 		if s, ok := ls.lockField(r, fg.Exclusive); !ok {
-			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
+			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok && !lff.Ignore {
 				pc.maybeFail(call.Pos(), "attempt to acquire %s (%s), but already held (locks: %s)", fieldName, s, ls.String())
 			}
 		}
@@ -337,12 +359,29 @@ func exclusiveStr(exclusive bool) string {
 // atomic functions are tracked by checkFieldAccess by looking directly at the
 // referrers (because ordering doesn't matter there, so we need not scan in
 // instruction order).
-func (pc *passContext) checkFunctionCall(call callCommon, fn *ssa.Function, lff *lockFunctionFacts, ls *lockState) {
-	// Check all guards required are held.
+func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *lockFunctionFacts, ls *lockState) {
+	// Extract the "receiver" properly.
+	var rcvr ssa.Value
+	if call.Common().Method != nil {
+		// This is an interface dispatch for sync.Locker.
+		rcvr = call.Common().Value
+	} else if args := call.Common().Args; len(args) > 0 && fn.Type().(*types.Signature).Recv() != nil {
+		// This matches the signature for the relevant
+		// sync.Lock/sync.Unlock functions below.
+		rcvr = args[0]
+	}
+	// Note that at this point, rcvr may be nil, but it should not match any
+	// of the function signatures below where rcvr may be used.
+
+	// Check all guards required are held. Note that this explicitly does
+	// not include aliases, hence false being passed below.
 	for fieldName, fg := range lff.HeldOnEntry {
+		if fg.IsAlias {
+			continue
+		}
 		r := fg.resolveCall(call.Common().Args, call.Value())
 		if s, ok := ls.isHeld(r, fg.Exclusive); !ok {
-			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
+			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok && !lff.Ignore {
 				pc.maybeFail(call.Pos(), "must hold %s %s (%s) to call %s, but not held (locks: %s)", fieldName, exclusiveStr(fg.Exclusive), s, fn.Name(), ls.String())
 			} else {
 				// Force the lock to be acquired.
@@ -352,19 +391,19 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *ssa.Function, lff 
 	}
 
 	// Update all lock state accordingly.
-	pc.postFunctionCallUpdate(call, lff, ls)
+	pc.postFunctionCallUpdate(call, lff, ls, false /* aliases */)
 
 	// Check if it's a method dispatch for something in the sync package.
 	// See: https://godoc.org/golang.org/x/tools/go/ssa#Function
-	if fn.Package() != nil && fn.Package().Pkg.Name() == "sync" && fn.Signature.Recv() != nil {
+	if fn.Pkg() != nil && fn.Pkg().Name() == "sync" {
 		isExclusive := false
 		switch fn.Name() {
 		case "Lock":
 			isExclusive = true
 			fallthrough
 		case "RLock":
-			if s, ok := ls.lockField(resolvedValue{value: call.Common().Args[0], valid: true}, isExclusive); !ok {
-				if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
+			if s, ok := ls.lockField(resolvedValue{value: rcvr, valid: true}, isExclusive); !ok {
+				if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok && !lff.Ignore {
 					// Double locking a mutex that is already locked.
 					pc.maybeFail(call.Pos(), "%s already locked (locks: %s)", s, ls.String())
 				}
@@ -373,15 +412,15 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *ssa.Function, lff 
 			isExclusive = true
 			fallthrough
 		case "RUnlock":
-			if s, ok := ls.unlockField(resolvedValue{value: call.Common().Args[0], valid: true}, isExclusive); !ok {
-				if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
+			if s, ok := ls.unlockField(resolvedValue{value: rcvr, valid: true}, isExclusive); !ok {
+				if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok && !lff.Ignore {
 					// Unlocking something that is already unlocked.
 					pc.maybeFail(call.Pos(), "%s already unlocked or locked differently (locks: %s)", s, ls.String())
 				}
 			}
 		case "DowngradeLock":
 			if s, ok := ls.downgradeField(resolvedValue{value: call.Common().Args[0], valid: true}); !ok {
-				if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok {
+				if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok && !lff.Ignore {
 					// Downgrading something that may not be downgraded.
 					pc.maybeFail(call.Pos(), "%s already unlocked or not exclusive (locks: %s)", s, ls.String())
 				}
@@ -392,7 +431,7 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *ssa.Function, lff 
 
 // checkClosure forks the lock state, and creates a binding for the FreeVars of
 // the closure. This allows the analysis to resolve the closure.
-func (pc *passContext) checkClosure(call callCommon, fn *ssa.MakeClosure, ls *lockState) {
+func (pc *passContext) checkClosure(call callCommon, fn *ssa.MakeClosure, lff *lockFunctionFacts, ls *lockState) {
 	clls := ls.fork()
 	clfn := fn.Fn.(*ssa.Function)
 	for i, fv := range clfn.FreeVars {
@@ -402,8 +441,10 @@ func (pc *passContext) checkClosure(call callCommon, fn *ssa.MakeClosure, ls *lo
 	// Note that this is *not* a call to check function call, which checks
 	// against the function preconditions. Instead, this does a fresh
 	// analysis of the function from source code with a different state.
-	var nolff lockFunctionFacts
-	pc.checkFunction(call, clfn, &nolff, clls, true /* force */)
+	nlff := lockFunctionFacts{
+		Ignore: lff.Ignore, // Inherit ignore.
+	}
+	pc.checkFunction(call, clfn, &nlff, clls, true /* force */)
 }
 
 // freshAlloc indicates that v has been allocated within the local scope. There
@@ -455,7 +496,7 @@ type callCommon interface {
 
 // checkInstruction checks the legality the single instruction based on the
 // current lockState.
-func (pc *passContext) checkInstruction(inst ssa.Instruction, ls *lockState) (*ssa.Return, *lockState) {
+func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionFacts, ls *lockState) (*ssa.Return, *lockState) {
 	switch x := inst.(type) {
 	case *ssa.Store:
 		// Record that this value is holding this other value. This is
@@ -468,52 +509,55 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, ls *lockState) (*s
 		// state, but this is intentional.
 		ls.store(x.Addr, x.Val)
 	case *ssa.Field:
-		if !freshAlloc(x.X) {
+		if !freshAlloc(x.X) && !lff.Ignore {
 			pc.checkFieldAccess(x, x.X, x.Field, ls, false)
 		}
 	case *ssa.FieldAddr:
-		if !freshAlloc(x.X) {
+		if !freshAlloc(x.X) && !lff.Ignore {
 			pc.checkFieldAccess(x, x.X, x.Field, ls, isWrite(x))
 		}
 	case *ssa.Call:
-		pc.checkCall(x, ls)
+		pc.checkCall(x, lff, ls)
 	case *ssa.Defer:
 		ls.pushDefer(x)
 	case *ssa.RunDefers:
 		for d := ls.popDefer(); d != nil; d = ls.popDefer() {
-			pc.checkCall(d, ls)
+			pc.checkCall(d, lff, ls)
 		}
 	case *ssa.MakeClosure:
-		refs := x.Referrers()
-		if refs == nil {
-			// This is strange, it's not used? Ignore this case,
-			// since it will probably be optimized away.
-			return nil, nil
-		}
-		hasNonCall := false
-		for _, ref := range *refs {
-			switch ref.(type) {
-			case *ssa.Call, *ssa.Defer:
-				// Analysis will be done on the call itself
-				// subsequently, including the lock state at
-				// the time of the call.
-			default:
-				// We need to analyze separately. Per below,
-				// this means that we'll analyze at closure
-				// construction time no zero assumptions about
-				// when it will be called.
-				hasNonCall = true
+		if refs := x.Referrers(); refs != nil {
+			var (
+				calls    int
+				nonCalls int
+			)
+			for _, ref := range *refs {
+				switch ref.(type) {
+				case *ssa.Call, *ssa.Defer:
+					// Analysis will be done on the call
+					// itself subsequently, including the
+					// lock state at the time of the call.
+					calls++
+				default:
+					// We need to analyze separately. Per
+					// below, this means that we'll analyze
+					// at closure construction time no zero
+					// assumptions about when it will be
+					// called.
+					nonCalls++
+				}
 			}
-		}
-		if !hasNonCall {
-			return nil, nil
+			if calls > 0 && nonCalls == 0 {
+				return nil, nil
+			}
 		}
 		// Analyze the closure without bindings. This means that we
 		// assume no lock facts or have any existing lock state. Only
 		// trivial closures are acceptable in this case.
 		clfn := x.Fn.(*ssa.Function)
-		var nolff lockFunctionFacts
-		pc.checkFunction(nil, clfn, &nolff, nil, false /* force */)
+		nlff := lockFunctionFacts{
+			Ignore: lff.Ignore, // Inherit ignore.
+		}
+		pc.checkFunction(nil, clfn, &nlff, nil, false /* force */)
 	case *ssa.Return:
 		return x, ls // Valid return state.
 	}
@@ -531,14 +575,14 @@ func (pc *passContext) checkBasicBlock(fn *ssa.Function, block *ssa.BasicBlock, 
 	// Analyze this block.
 	post := entry.fork()
 	for _, inst := range block.Instrs {
-		rv, rls = pc.checkInstruction(inst, post)
+		rv, rls = pc.checkInstruction(inst, lff, post)
 		if rls != nil {
 			failed := false
 			// Validate held locks.
 			for fieldName, fg := range lff.HeldOnExit {
 				r := fg.resolveStatic(fn, rv)
 				if s, ok := rls.isHeld(r, fg.Exclusive); !ok {
-					if _, ok := pc.forced[pc.positionKey(rv.Pos())]; !ok {
+					if _, ok := pc.forced[pc.positionKey(rv.Pos())]; !ok && !lff.Ignore {
 						pc.maybeFail(rv.Pos(), "lock %s (%s) not held %s (locks: %s)", fieldName, s, exclusiveStr(fg.Exclusive), rls.String())
 						failed = true
 					} else {
@@ -548,7 +592,7 @@ func (pc *passContext) checkBasicBlock(fn *ssa.Function, block *ssa.BasicBlock, 
 				}
 			}
 			// Check for other locks, but only if the above didn't trip.
-			if !failed && rls.count() != len(lff.HeldOnExit) {
+			if !failed && rls.count() != len(lff.HeldOnExit) && !lff.Ignore {
 				pc.maybeFail(rv.Pos(), "return with unexpected locks held (locks: %s)", rls.String())
 			}
 		}
@@ -637,12 +681,15 @@ func (pc *passContext) checkFunction(call callCommon, fn *ssa.Function, lff *loc
 	// for the method to be invoked. Note that in the overwhleming majority
 	// of cases, parent will be nil. However, in the case of closures and
 	// anonymous functions, we may start with a non-nil lock state.
+	//
+	// Note that this will include all aliases, which are also released
+	// appropriately below.
 	ls := parent.fork()
 	for fieldName, fg := range lff.HeldOnEntry {
 		// The first is the method object itself so we skip that when looking
 		// for receiver/function parameters.
 		r := fg.resolveStatic(fn, call.Value())
-		if s, ok := ls.lockField(r, fg.Exclusive); !ok {
+		if s, ok := ls.lockField(r, fg.Exclusive); !ok && !lff.Ignore {
 			// This can only happen if the same value is declared
 			// multiple times, and should be caught by the earlier
 			// fact scanning. Keep it here as a sanity check.
@@ -661,6 +708,6 @@ func (pc *passContext) checkFunction(call callCommon, fn *ssa.Function, lff *loc
 	// Update all lock state accordingly. This will be called only if we
 	// are doing inline analysis for e.g. an anonymous function.
 	if call != nil && parent != nil {
-		pc.postFunctionCallUpdate(call, lff, parent)
+		pc.postFunctionCallUpdate(call, lff, parent, true /* aliases */)
 	}
 }

--- a/tools/checklocks/annotations.go
+++ b/tools/checklocks/annotations.go
@@ -23,13 +23,16 @@ import (
 )
 
 const (
-	checkLocksAnnotation  = "// +checklocks:"
-	checkLocksAcquires    = "// +checklocksacquire:"
-	checkLocksReleases    = "// +checklocksrelease:"
-	checkLocksIgnore      = "// +checklocksignore"
-	checkLocksForce       = "// +checklocksforce"
-	checkLocksFail        = "// +checklocksfail"
-	checkAtomicAnnotation = "// +checkatomic"
+	checkLocksAnnotation     = "// +checklocks:"
+	checkLocksAnnotationRead = "// +checklocksread:"
+	checkLocksAcquires       = "// +checklocksacquire:"
+	checkLocksAcquiresRead   = "// +checklocksacquireread:"
+	checkLocksReleases       = "// +checklocksrelease:"
+	checkLocksReleasesRead   = "// +checklocksreleaseread:"
+	checkLocksIgnore         = "// +checklocksignore"
+	checkLocksForce          = "// +checklocksforce"
+	checkLocksFail           = "// +checklocksfail"
+	checkAtomicAnnotation    = "// +checkatomic"
 )
 
 // failData indicates an expected failure.

--- a/tools/checklocks/annotations.go
+++ b/tools/checklocks/annotations.go
@@ -32,6 +32,7 @@ const (
 	checkLocksIgnore         = "// +checklocksignore"
 	checkLocksForce          = "// +checklocksforce"
 	checkLocksFail           = "// +checklocksfail"
+	checkLocksAlias          = "// +checklocksalias:"
 	checkAtomicAnnotation    = "// +checkatomic"
 )
 

--- a/tools/checklocks/checklocks.go
+++ b/tools/checklocks/checklocks.go
@@ -118,7 +118,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	// Find all struct declarations and export relevant facts.
 	pc.forAllTypes(func(ts *ast.TypeSpec) {
 		if ss, ok := ts.Type.(*ast.StructType); ok {
-			pc.exportLockFieldFacts(ts, ss)
+			structType := pc.pass.TypesInfo.TypeOf(ts.Name).Underlying().(*types.Struct)
+			pc.exportLockFieldFacts(structType, ss)
 		}
 	})
 	pc.forAllTypes(func(ts *ast.TypeSpec) {
@@ -128,7 +129,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	})
 	pc.forAllTypes(func(ts *ast.TypeSpec) {
 		if ss, ok := ts.Type.(*ast.StructType); ok {
-			pc.exportLockGuardFacts(ts, ss)
+			structType := pc.pass.TypesInfo.TypeOf(ts.Name).Underlying().(*types.Struct)
+			pc.exportLockGuardFacts(structType, ss)
 		}
 	})
 	// Check all alignments.

--- a/tools/checklocks/facts.go
+++ b/tools/checklocks/facts.go
@@ -169,6 +169,9 @@ type functionGuard struct {
 
 	// FieldList is the traversal path to the object.
 	FieldList fieldList
+
+	// Exclusive indicates an exclusive lock is required.
+	Exclusive bool
 }
 
 // resolveReturn resolves a return value.
@@ -265,7 +268,7 @@ type lockFunctionFacts struct {
 func (*lockFunctionFacts) AFact() {}
 
 // checkGuard validates the guardName.
-func (lff *lockFunctionFacts) checkGuard(pc *passContext, d *ast.FuncDecl, guardName string, allowReturn bool) (functionGuard, bool) {
+func (lff *lockFunctionFacts) checkGuard(pc *passContext, d *ast.FuncDecl, guardName string, exclusive bool, allowReturn bool) (functionGuard, bool) {
 	if _, ok := lff.HeldOnEntry[guardName]; ok {
 		pc.maybeFail(d.Pos(), "annotation %s specified more than once, already required", guardName)
 		return functionGuard{}, false
@@ -274,13 +277,13 @@ func (lff *lockFunctionFacts) checkGuard(pc *passContext, d *ast.FuncDecl, guard
 		pc.maybeFail(d.Pos(), "annotation %s specified more than once, already acquired", guardName)
 		return functionGuard{}, false
 	}
-	fg, ok := pc.findFunctionGuard(d, guardName, allowReturn)
+	fg, ok := pc.findFunctionGuard(d, guardName, exclusive, allowReturn)
 	return fg, ok
 }
 
 // addGuardedBy adds a field to both HeldOnEntry and HeldOnExit.
-func (lff *lockFunctionFacts) addGuardedBy(pc *passContext, d *ast.FuncDecl, guardName string) {
-	if fg, ok := lff.checkGuard(pc, d, guardName, false /* allowReturn */); ok {
+func (lff *lockFunctionFacts) addGuardedBy(pc *passContext, d *ast.FuncDecl, guardName string, exclusive bool) {
+	if fg, ok := lff.checkGuard(pc, d, guardName, exclusive, false /* allowReturn */); ok {
 		if lff.HeldOnEntry == nil {
 			lff.HeldOnEntry = make(map[string]functionGuard)
 		}
@@ -293,8 +296,8 @@ func (lff *lockFunctionFacts) addGuardedBy(pc *passContext, d *ast.FuncDecl, gua
 }
 
 // addAcquires adds a field to HeldOnExit.
-func (lff *lockFunctionFacts) addAcquires(pc *passContext, d *ast.FuncDecl, guardName string) {
-	if fg, ok := lff.checkGuard(pc, d, guardName, true /* allowReturn */); ok {
+func (lff *lockFunctionFacts) addAcquires(pc *passContext, d *ast.FuncDecl, guardName string, exclusive bool) {
+	if fg, ok := lff.checkGuard(pc, d, guardName, exclusive, true /* allowReturn */); ok {
 		if lff.HeldOnExit == nil {
 			lff.HeldOnExit = make(map[string]functionGuard)
 		}
@@ -303,8 +306,8 @@ func (lff *lockFunctionFacts) addAcquires(pc *passContext, d *ast.FuncDecl, guar
 }
 
 // addReleases adds a field to HeldOnEntry.
-func (lff *lockFunctionFacts) addReleases(pc *passContext, d *ast.FuncDecl, guardName string) {
-	if fg, ok := lff.checkGuard(pc, d, guardName, false /* allowReturn */); ok {
+func (lff *lockFunctionFacts) addReleases(pc *passContext, d *ast.FuncDecl, guardName string, exclusive bool) {
+	if fg, ok := lff.checkGuard(pc, d, guardName, exclusive, false /* allowReturn */); ok {
 		if lff.HeldOnEntry == nil {
 			lff.HeldOnEntry = make(map[string]functionGuard)
 		}
@@ -313,7 +316,7 @@ func (lff *lockFunctionFacts) addReleases(pc *passContext, d *ast.FuncDecl, guar
 }
 
 // fieldListFor returns the fieldList for the given object.
-func (pc *passContext) fieldListFor(pos token.Pos, fieldObj types.Object, index int, fieldName string, checkMutex bool) (int, bool) {
+func (pc *passContext) fieldListFor(pos token.Pos, fieldObj types.Object, index int, fieldName string, checkMutex bool, exclusive bool) (int, bool) {
 	var lff lockFieldFacts
 	if !pc.pass.ImportObjectFact(fieldObj, &lff) {
 		// This should not happen: we export facts for all fields.
@@ -321,7 +324,11 @@ func (pc *passContext) fieldListFor(pos token.Pos, fieldObj types.Object, index 
 	}
 	// Check that it is indeed a mutex.
 	if checkMutex && !lff.IsMutex && !lff.IsRWMutex {
-		pc.maybeFail(pos, "field %s is not a mutex or an rwmutex", fieldName)
+		pc.maybeFail(pos, "field %s is not a Mutex or an RWMutex", fieldName)
+		return 0, false
+	}
+	if checkMutex && !exclusive && !lff.IsRWMutex {
+		pc.maybeFail(pos, "field %s must be a RWMutex, but it is not", fieldName)
 		return 0, false
 	}
 	// Return the resolution path.
@@ -332,14 +339,14 @@ func (pc *passContext) fieldListFor(pos token.Pos, fieldObj types.Object, index 
 }
 
 // resolveOneField resolves a field in a single struct.
-func (pc *passContext) resolveOneField(pos token.Pos, structType *types.Struct, fieldName string, checkMutex bool) (fl fieldList, fieldObj types.Object, ok bool) {
+func (pc *passContext) resolveOneField(pos token.Pos, structType *types.Struct, fieldName string, checkMutex bool, exclusive bool) (fl fieldList, fieldObj types.Object, ok bool) {
 	// Scan to match the next field.
 	for i := 0; i < structType.NumFields(); i++ {
 		fieldObj := structType.Field(i)
 		if fieldObj.Name() != fieldName {
 			continue
 		}
-		flOne, ok := pc.fieldListFor(pos, fieldObj, i, fieldName, checkMutex)
+		flOne, ok := pc.fieldListFor(pos, fieldObj, i, fieldName, checkMutex, exclusive)
 		if !ok {
 			return nil, nil, false
 		}
@@ -360,8 +367,8 @@ func (pc *passContext) resolveOneField(pos token.Pos, structType *types.Struct, 
 		// Need to check that there is a resolution path. If there is
 		// no resolution path that's not a failure: we just continue
 		// scanning the next embed to find a match.
-		flEmbed, okEmbed := pc.fieldListFor(pos, fieldObj, i, fieldName, false)
-		flCont, fieldObjCont, okCont := pc.resolveOneField(pos, structType, fieldName, checkMutex)
+		flEmbed, okEmbed := pc.fieldListFor(pos, fieldObj, i, fieldName, false, exclusive)
+		flCont, fieldObjCont, okCont := pc.resolveOneField(pos, structType, fieldName, checkMutex, exclusive)
 		if okEmbed && okCont {
 			fl = append(fl, flEmbed)
 			fl = append(fl, flCont...)
@@ -376,9 +383,9 @@ func (pc *passContext) resolveOneField(pos token.Pos, structType *types.Struct, 
 //
 // Note that this checks that the final element is a mutex of some kind, and
 // will fail appropriately.
-func (pc *passContext) resolveField(pos token.Pos, structType *types.Struct, parts []string) (fl fieldList, ok bool) {
+func (pc *passContext) resolveField(pos token.Pos, structType *types.Struct, parts []string, exclusive bool) (fl fieldList, ok bool) {
 	for partNumber, fieldName := range parts {
-		flOne, fieldObj, ok := pc.resolveOneField(pos, structType, fieldName, partNumber >= len(parts)-1 /* checkMutex */)
+		flOne, fieldObj, ok := pc.resolveOneField(pos, structType, fieldName, partNumber >= len(parts)-1 /* checkMutex */, exclusive)
 		if !ok {
 			// Error already reported.
 			return nil, false
@@ -479,10 +486,9 @@ func (pc *passContext) exportLockGuardFacts(structType *types.Struct, ss *ast.St
 								return
 							}
 						}
-						fl, ok := pc.resolveField(fieldObj.Pos(), structType, strings.Split(guardName, "."))
+						fl, ok := pc.resolveField(fieldObj.Pos(), structType, strings.Split(guardName, "."), true /* exclusive */)
 						if ok {
-							// If we successfully resolved
-							// the field, then save it.
+							// If we successfully resolved the field, then save it.
 							if lgf.GuardedBy == nil {
 								lgf.GuardedBy = make(map[string]fieldList)
 							}
@@ -493,6 +499,13 @@ func (pc *passContext) exportLockGuardFacts(structType *types.Struct, ss *ast.St
 							}
 							lgf.HatGuard[guardName] = false
 						}
+					},
+					// N.B. We support only the vanilla
+					// annotation on individual fields. If
+					// the field is a read lock, then we
+					// will allow read access by default.
+					checkLocksAnnotationRead: func(guardName string) {
+						pc.maybeFail(fieldObj.Pos(), "annotation %s not legal on fields", guardName)
 					},
 				})
 			}
@@ -554,7 +567,7 @@ func (pc *passContext) exportHatGuards(ts *ast.TypeSpec, ss *ast.StructType) {
 
 		var lgf lockGuardFacts
 
-		fl, _, ok := pc.resolveOneField(fieldObj.Pos(), structType, guardName /*checkMutex*/, true)
+		fl, _, ok := pc.resolveOneField(fieldObj.Pos(), structType, guardName, true /* checkMutex */, true /* exclusive */)
 		if ok {
 			if lgf.GuardedBy == nil {
 				lgf.GuardedBy = make(map[string]fieldList)
@@ -587,7 +600,7 @@ func countFields(fl []*ast.Field) (count int) {
 }
 
 // matchFieldList attempts to match the given field.
-func (pc *passContext) matchFieldList(pos token.Pos, fl []*ast.Field, guardName string) (functionGuard, bool) {
+func (pc *passContext) matchFieldList(pos token.Pos, fl []*ast.Field, guardName string, exclusive bool) (functionGuard, bool) {
 	parts := strings.Split(guardName, ".")
 	parameterName := parts[0]
 	parameterNumber := 0
@@ -618,8 +631,9 @@ func (pc *passContext) matchFieldList(pos token.Pos, fl []*ast.Field, guardName 
 			}
 			fg := functionGuard{
 				ParameterNumber: parameterNumber,
+				Exclusive:       exclusive,
 			}
-			fl, ok := pc.resolveField(pos, structType, parts[1:])
+			fl, ok := pc.resolveField(pos, structType, parts[1:], exclusive)
 			fg.FieldList = fl
 			return fg, ok // If ok is false, already failed.
 		}
@@ -631,7 +645,7 @@ func (pc *passContext) matchFieldList(pos token.Pos, fl []*ast.Field, guardName 
 // particular string of the 'a.b'.
 //
 // This function will report any errors directly.
-func (pc *passContext) findFunctionGuard(d *ast.FuncDecl, guardName string, allowReturn bool) (functionGuard, bool) {
+func (pc *passContext) findFunctionGuard(d *ast.FuncDecl, guardName string, exclusive bool, allowReturn bool) (functionGuard, bool) {
 	var (
 		parameterList []*ast.Field
 		returnList    []*ast.Field
@@ -642,14 +656,14 @@ func (pc *passContext) findFunctionGuard(d *ast.FuncDecl, guardName string, allo
 	if d.Type.Params != nil {
 		parameterList = append(parameterList, d.Type.Params.List...)
 	}
-	if fg, ok := pc.matchFieldList(d.Pos(), parameterList, guardName); ok {
+	if fg, ok := pc.matchFieldList(d.Pos(), parameterList, guardName, exclusive); ok {
 		return fg, ok
 	}
 	if allowReturn {
 		if d.Type.Results != nil {
 			returnList = append(returnList, d.Type.Results.List...)
 		}
-		if fg, ok := pc.matchFieldList(d.Pos(), returnList, guardName); ok {
+		if fg, ok := pc.matchFieldList(d.Pos(), returnList, guardName, exclusive); ok {
 			// Fix this up to apply to the return value, as noted
 			// in fg.ParameterNumber. For the ssa analysis, we must
 			// record whether this has multiple results, since
@@ -683,9 +697,12 @@ func (pc *passContext) exportFunctionFacts(d *ast.FuncDecl) {
 				// extremely rare.
 				lff.Ignore = true
 			},
-			checkLocksAnnotation: func(guardName string) { lff.addGuardedBy(pc, d, guardName) },
-			checkLocksAcquires:   func(guardName string) { lff.addAcquires(pc, d, guardName) },
-			checkLocksReleases:   func(guardName string) { lff.addReleases(pc, d, guardName) },
+			checkLocksAnnotation:     func(guardName string) { lff.addGuardedBy(pc, d, guardName, true /* exclusive */) },
+			checkLocksAnnotationRead: func(guardName string) { lff.addGuardedBy(pc, d, guardName, false /* exclusive */) },
+			checkLocksAcquires:       func(guardName string) { lff.addAcquires(pc, d, guardName, true /* exclusive */) },
+			checkLocksAcquiresRead:   func(guardName string) { lff.addAcquires(pc, d, guardName, false /* exclusive */) },
+			checkLocksReleases:       func(guardName string) { lff.addReleases(pc, d, guardName, true /* exclusive */) },
+			checkLocksReleasesRead:   func(guardName string) { lff.addReleases(pc, d, guardName, false /* exclusive */) },
 		})
 	}
 

--- a/tools/checklocks/facts.go
+++ b/tools/checklocks/facts.go
@@ -167,6 +167,9 @@ type functionGuard struct {
 	// that the field must be extracted from a tuple.
 	NeedsExtract bool
 
+	// IsAlias indicates that this guard is an alias.
+	IsAlias bool
+
 	// FieldList is the traversal path to the object.
 	FieldList fieldList
 
@@ -315,6 +318,36 @@ func (lff *lockFunctionFacts) addReleases(pc *passContext, d *ast.FuncDecl, guar
 	}
 }
 
+// addAlias adds an alias.
+func (lff *lockFunctionFacts) addAlias(pc *passContext, d *ast.FuncDecl, guardName string) {
+	// Parse the alias.
+	parts := strings.Split(guardName, "=")
+	if len(parts) != 2 {
+		pc.maybeFail(d.Pos(), "invalid annotation %s for alias", guardName)
+		return
+	}
+
+	// Parse the actual guard.
+	fg, ok := lff.checkGuard(pc, d, parts[0], true /* exclusive */, true /* allowReturn */)
+	if !ok {
+		return
+	}
+	fg.IsAlias = true
+
+	// Find the existing specification.
+	_, entryOk := lff.HeldOnEntry[parts[1]]
+	if entryOk {
+		lff.HeldOnEntry[guardName] = fg
+	}
+	_, exitOk := lff.HeldOnExit[parts[1]]
+	if exitOk {
+		lff.HeldOnExit[guardName] = fg
+	}
+	if !entryOk && !exitOk {
+		pc.maybeFail(d.Pos(), "alias annotation %s does not refer to an existing guard", guardName)
+	}
+}
+
 // fieldListFor returns the fieldList for the given object.
 func (pc *passContext) fieldListFor(pos token.Pos, fieldObj types.Object, index int, fieldName string, checkMutex bool, exclusive bool) (int, bool) {
 	var lff lockFieldFacts
@@ -406,6 +439,7 @@ func (pc *passContext) resolveField(pos token.Pos, structType *types.Struct, par
 var (
 	mutexRE   = regexp.MustCompile("((.*/)|^)sync.(CrossGoroutineMutex|Mutex)")
 	rwMutexRE = regexp.MustCompile("((.*/)|^)sync.(CrossGoroutineRWMutex|RWMutex)")
+	lockerRE  = regexp.MustCompile("((.*/)|^)sync.Locker")
 )
 
 // exportLockFieldFacts finds all struct fields that are mutexes, and ensures
@@ -429,9 +463,14 @@ func (pc *passContext) exportLockFieldFacts(structType *types.Struct, ss *ast.St
 			lff.IsMutex = true
 		case rwMutexRE.MatchString(s):
 			lff.IsRWMutex = true
+		case lockerRE.MatchString(s):
+			lff.IsMutex = true
 		}
 		// Save whether this is a pointer.
 		_, lff.IsPointer = fieldObj.Type().Underlying().(*types.Pointer)
+		if !lff.IsPointer {
+			_, lff.IsPointer = fieldObj.Type().Underlying().(*types.Interface)
+		}
 		// We must always export the lockFieldFacts, since traversal
 		// can take place along any object in the struct.
 		pc.pass.ExportObjectFact(fieldObj, lff)
@@ -703,6 +742,7 @@ func (pc *passContext) exportFunctionFacts(d *ast.FuncDecl) {
 			checkLocksAcquiresRead:   func(guardName string) { lff.addAcquires(pc, d, guardName, false /* exclusive */) },
 			checkLocksReleases:       func(guardName string) { lff.addReleases(pc, d, guardName, true /* exclusive */) },
 			checkLocksReleasesRead:   func(guardName string) { lff.addReleases(pc, d, guardName, false /* exclusive */) },
+			checkLocksAlias:          func(guardName string) { lff.addAlias(pc, d, guardName) },
 		})
 	}
 

--- a/tools/checklocks/state.go
+++ b/tools/checklocks/state.go
@@ -29,7 +29,9 @@ type lockState struct {
 	// lockedMutexes is used to track which mutexes in a given struct are
 	// currently locked. Note that most of the heavy lifting is done by
 	// valueAsString below, which maps to specific structure fields, etc.
-	lockedMutexes []string
+	//
+	// The value indicates whether this is an exclusive lock.
+	lockedMutexes map[string]bool
 
 	// stored stores values that have been stored in memory, bound to
 	// FreeVars or passed as Parameterse.
@@ -51,7 +53,7 @@ type lockState struct {
 func newLockState() *lockState {
 	refs := int32(1) // Not shared.
 	return &lockState{
-		lockedMutexes: make([]string, 0),
+		lockedMutexes: make(map[string]bool),
 		used:          make(map[ssa.Value]struct{}),
 		stored:        make(map[ssa.Value]ssa.Value),
 		defers:        make([]*ssa.Defer, 0),
@@ -79,8 +81,10 @@ func (l *lockState) fork() *lockState {
 func (l *lockState) modify() {
 	if atomic.LoadInt32(l.refs) > 1 {
 		// Copy the lockedMutexes.
-		lm := make([]string, len(l.lockedMutexes))
-		copy(lm, l.lockedMutexes)
+		lm := make(map[string]bool)
+		for k, v := range l.lockedMutexes {
+			lm[k] = v
+		}
 		l.lockedMutexes = lm
 
 		// Copy the stored values.
@@ -106,55 +110,76 @@ func (l *lockState) modify() {
 }
 
 // isHeld indicates whether the field is held is not.
-func (l *lockState) isHeld(rv resolvedValue) (string, bool) {
+func (l *lockState) isHeld(rv resolvedValue, exclusiveRequired bool) (string, bool) {
 	if !rv.valid {
 		return rv.valueAsString(l), false
 	}
 	s := rv.valueAsString(l)
-	for _, k := range l.lockedMutexes {
-		if k == s {
-			return s, true
-		}
+	isExclusive, ok := l.lockedMutexes[s]
+	if !ok {
+		return s, false
 	}
-	return s, false
+	// Accept a weaker lock if exclusiveRequired is false.
+	if exclusiveRequired && !isExclusive {
+		return s, false
+	}
+	return s, true
 }
 
 // lockField locks the given field.
 //
 // If false is returned, the field was already locked.
-func (l *lockState) lockField(rv resolvedValue) (string, bool) {
+func (l *lockState) lockField(rv resolvedValue, exclusive bool) (string, bool) {
 	if !rv.valid {
 		return rv.valueAsString(l), false
 	}
 	s := rv.valueAsString(l)
-	for _, k := range l.lockedMutexes {
-		if k == s {
-			return s, false
-		}
+	if _, ok := l.lockedMutexes[s]; ok {
+		return s, false
 	}
 	l.modify()
-	l.lockedMutexes = append(l.lockedMutexes, s)
+	l.lockedMutexes[s] = exclusive
 	return s, true
 }
 
 // unlockField unlocks the given field.
 //
 // If false is returned, the field was not locked.
-func (l *lockState) unlockField(rv resolvedValue) (string, bool) {
+func (l *lockState) unlockField(rv resolvedValue, exclusive bool) (string, bool) {
 	if !rv.valid {
 		return rv.valueAsString(l), false
 	}
 	s := rv.valueAsString(l)
-	for i, k := range l.lockedMutexes {
-		if k == s {
-			// Copy the last lock in and truncate.
-			l.modify()
-			l.lockedMutexes[i] = l.lockedMutexes[len(l.lockedMutexes)-1]
-			l.lockedMutexes = l.lockedMutexes[:len(l.lockedMutexes)-1]
-			return s, true
-		}
+	wasExclusive, ok := l.lockedMutexes[s]
+	if !ok {
+		return s, false
 	}
-	return s, false
+	if wasExclusive != exclusive {
+		return s, false
+	}
+	l.modify()
+	delete(l.lockedMutexes, s)
+	return s, true
+}
+
+// downgradeField downgrades the given field.
+//
+// If false was returned, the field was not downgraded.
+func (l *lockState) downgradeField(rv resolvedValue) (string, bool) {
+	if !rv.valid {
+		return rv.valueAsString(l), false
+	}
+	s := rv.valueAsString(l)
+	wasExclusive, ok := l.lockedMutexes[s]
+	if !ok {
+		return s, false
+	}
+	if !wasExclusive {
+		return s, false
+	}
+	l.modify()
+	l.lockedMutexes[s] = false // Downgraded.
+	return s, true
 }
 
 // store records an alias.
@@ -165,16 +190,17 @@ func (l *lockState) store(addr ssa.Value, v ssa.Value) {
 
 // isSubset indicates other holds all the locks held by l.
 func (l *lockState) isSubset(other *lockState) bool {
-	held := 0 // Number in l, held by other.
-	for _, k := range l.lockedMutexes {
-		for _, ok := range other.lockedMutexes {
-			if k == ok {
-				held++
-				break
-			}
+	for k, isExclusive := range l.lockedMutexes {
+		otherExclusive, otherOk := other.lockedMutexes[k]
+		if !otherOk {
+			return false
+		}
+		// Accept weaker locks as a subset.
+		if isExclusive && !otherExclusive {
+			return false
 		}
 	}
-	return held >= len(l.lockedMutexes)
+	return true
 }
 
 // count indicates the number of locks held.
@@ -212,19 +238,19 @@ func (l *lockState) join(other *lockState) *lockState {
 	}
 
 	// Take the intersection of locked mutexes
-	present := make(map[string]bool, len(other.lockedMutexes))
-	for _, om := range other.lockedMutexes {
-		present[om] = true
-	}
-	rls.modify()
-	var w int
-	for i, n := 0, len(rls.lockedMutexes); i < n; i++ {
-		if m := rls.lockedMutexes[i]; present[m] {
-			rls.lockedMutexes[w] = m
-			w++
+	for k, isExclusive := range rls.lockedMutexes {
+		isOtherExclusive, found := other.lockedMutexes[k]
+		if !found {
+			rls.modify()
+			delete(rls.lockedMutexes, k)
+			continue
+		}
+
+		if isExclusive != isOtherExclusive {
+			rls.modify()
+			rls.lockedMutexes[k] = false
 		}
 	}
-	rls.lockedMutexes = rls.lockedMutexes[:w]
 
 	return rls
 }
@@ -335,7 +361,12 @@ func (l *lockState) String() string {
 	if l.count() == 0 {
 		return "no locks held"
 	}
-	return strings.Join(l.lockedMutexes, ",")
+	keys := make([]string, 0, len(l.lockedMutexes))
+	for k, exclusive := range l.lockedMutexes {
+		// Include the exclusive status of each lock.
+		keys = append(keys, fmt.Sprintf("%s %s", k, exclusiveStr(exclusive)))
+	}
+	return strings.Join(keys, ",")
 }
 
 // pushDefer pushes a defer onto the stack.

--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -6,6 +6,7 @@ go_library(
     name = "test",
     srcs = [
         "alignment.go",
+        "anon.go",
         "atomics.go",
         "basics.go",
         "branches.go",

--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -5,6 +5,7 @@ package(licenses = ["notice"])
 go_library(
     name = "test",
     srcs = [
+        "aliases.go",
         "alignment.go",
         "anon.go",
         "atomics.go",
@@ -13,6 +14,7 @@ go_library(
         "closures.go",
         "defer.go",
         "incompat.go",
+        "locker.go",
         "methods.go",
         "parameters.go",
         "return.go",

--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -16,6 +16,7 @@ go_library(
         "methods.go",
         "parameters.go",
         "return.go",
+        "rwmutex.go",
         "test.go",
         "infer.go",
     ],

--- a/tools/checklocks/test/aliases.go
+++ b/tools/checklocks/test/aliases.go
@@ -1,0 +1,26 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+// +checklocks:tc.mu
+// +checklocksalias:tc2.mu=tc.mu
+func testAliasValid(tc *oneGuardStruct, tc2 *oneGuardStruct) {
+	tc2.guardedField = 1
+}
+
+// +checklocks:tc.mu
+func testAliasInvalid(tc *oneGuardStruct, tc2 *oneGuardStruct) {
+	tc2.guardedField = 1 // +checklocksfail
+}

--- a/tools/checklocks/test/anon.go
+++ b/tools/checklocks/test/anon.go
@@ -1,0 +1,35 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import "sync"
+
+type anonStruct struct {
+	anon struct {
+		mu sync.RWMutex
+		// +checklocks:mu
+		x int
+	}
+}
+
+func testAnonAccessValid(tc *anonStruct) {
+	tc.anon.mu.Lock()
+	tc.anon.x = 1
+	tc.anon.mu.Unlock()
+}
+
+func testAnonAccessInvalid(tc *anonStruct) {
+	tc.anon.x = 1 // +checklocksfail
+}

--- a/tools/checklocks/test/basics.go
+++ b/tools/checklocks/test/basics.go
@@ -108,14 +108,14 @@ type rwGuardStruct struct {
 
 func testRWValidRead(tc *rwGuardStruct) {
 	tc.rwMu.Lock()
-	tc.guardedField = 1
+	_ = tc.guardedField
 	tc.rwMu.Unlock()
 }
 
 func testRWValidWrite(tc *rwGuardStruct) {
-	tc.rwMu.RLock()
+	tc.rwMu.Lock()
 	tc.guardedField = 2
-	tc.rwMu.RUnlock()
+	tc.rwMu.Unlock()
 }
 
 func testRWInvalidWrite(tc *rwGuardStruct) {

--- a/tools/checklocks/test/branches.go
+++ b/tools/checklocks/test/branches.go
@@ -54,3 +54,19 @@ func testInconsistentBranching(tc *oneGuardStruct) { // +checklocksfail:2
 		tc.mu.Unlock() // +checklocksforce
 	}
 }
+
+func testUnboundedLocks(tc []*oneGuardStruct) {
+	for _, l := range tc {
+		l.mu.Lock()
+	}
+	// This test should have the above *not fail*, though the exact
+	// lock state cannot be tracked through the below. Therefore, we
+	// expect the next loop to actually fail, and we force the unlock
+	// loop to succeed in exactly the same way.
+	for _, l := range tc {
+		l.guardedField = 1 // +checklocksfail
+	}
+	for _, l := range tc {
+		l.mu.Unlock() // +checklocksforce
+	}
+}

--- a/tools/checklocks/test/closures.go
+++ b/tools/checklocks/test/closures.go
@@ -53,6 +53,15 @@ func testClosureInline(tc *oneGuardStruct) {
 	tc.mu.Unlock()
 }
 
+// +checklocksignore
+func testClosureIgnore(tc *oneGuardStruct) {
+	// Inherit the checklocksignore.
+	x := func() {
+		tc.guardedField = 1
+	}
+	x()
+}
+
 func testAnonymousInvalid(tc *oneGuardStruct) {
 	// Invalid, as per testClosureInvalid above.
 	callAnonymous(func(tc *oneGuardStruct) {
@@ -87,6 +96,15 @@ func testAnonymousInline(tc *oneGuardStruct) {
 		tc.guardedField = 1
 	}(tc)
 	tc.mu.Unlock()
+}
+
+// +checklocksignore
+func testAnonymousIgnore(tc *oneGuardStruct) {
+	// Inherit the checklocksignore.
+	x := func(tc *oneGuardStruct) {
+		tc.guardedField = 1
+	}
+	x(tc)
 }
 
 //go:noinline

--- a/tools/checklocks/test/locker.go
+++ b/tools/checklocks/test/locker.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The gVisor Authors.
+// Copyright 2021 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,32 +14,20 @@
 
 package test
 
-import (
-	"sync"
-)
+import "sync"
 
-// badFieldsStruct verifies that refering invalid fields fails.
-type badFieldsStruct struct {
+type lockerStruct struct {
+	mu sync.Locker
 	// +checklocks:mu
-	x int // +checklocksfail
+	guardedField int
 }
 
-// redundantStruct verifies that redundant annotations fail.
-type redundantStruct struct {
-	mu sync.Mutex
-
-	// +checklocks:mu
-	// +checklocks:mu
-	x int // +checklocksfail
+func testLockerValid(tc *lockerStruct) {
+	tc.mu.Lock()
+	tc.guardedField = 1
+	tc.mu.Unlock()
 }
 
-// conflictsStruct verifies that conflicting annotations fail.
-type conflictsStruct struct {
-	// +checkatomicignore
-	// +checkatomic
-	x int // +checklocksfail
-
-	// +checkatomic
-	// +checkatomicignore
-	y int // +checklocksfail
+func testLockerInvalid(tc *lockerStruct) {
+	tc.guardedField = 1 // +checklocksfail
 }

--- a/tools/checklocks/test/rwmutex.go
+++ b/tools/checklocks/test/rwmutex.go
@@ -1,0 +1,52 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"sync"
+)
+
+// oneReadGuardStruct has one read-guarded field.
+type oneReadGuardStruct struct {
+	mu sync.RWMutex
+	// +checklocks:mu
+	guardedField int
+}
+
+func testRWAccessValidRead(tc *oneReadGuardStruct) {
+	tc.mu.Lock()
+	_ = tc.guardedField
+	tc.mu.Unlock()
+	tc.mu.RLock()
+	_ = tc.guardedField
+	tc.mu.RUnlock()
+}
+
+func testRWAccessValidWrite(tc *oneReadGuardStruct) {
+	tc.mu.Lock()
+	tc.guardedField = 1
+	tc.mu.Unlock()
+}
+
+func testRWAccessInvalidWrite(tc *oneReadGuardStruct) {
+	tc.guardedField = 2 // +checklocksfail
+	tc.mu.RLock()
+	tc.guardedField = 2 // +checklocksfail
+	tc.mu.RUnlock()
+}
+
+func testRWAccessInvalidRead(tc *oneReadGuardStruct) {
+	_ = tc.guardedField // +checklocksfail
+}


### PR DESCRIPTION
This CL merges additional feature support in the checklocks 
analyzer. The following features are added:

- support for anonymous structs
- support for shared and exclusive locks
- aliasing annotations
- annotations of `sync.Locker`