### PR TITLE
Use maps for locked mutexes in lock states 

### DIFF
--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -525,7 +525,7 @@ func (pc *passContext) checkBasicBlock(fn *ssa.Function, block *ssa.BasicBlock, 
 				}
 			}
 			// Check for other locks, but only if the above didn't trip.
-			if !failed && rls.count() != len(lff.HeldOnExit) {
+			if !failed && rls.numLocksHeld() != len(lff.HeldOnExit) {
 				pc.maybeFail(rv.Pos(), "return with unexpected locks held (locks: %s)", rls.String())
 			}
 		}

--- a/tools/checklocks/state.go
+++ b/tools/checklocks/state.go
@@ -20,6 +20,7 @@ import (
 	"go/types"
 	"strings"
 	"sync/atomic"
+	"sort"
 
 	"golang.org/x/tools/go/ssa"
 )
@@ -349,6 +350,8 @@ func (l *lockState) String() string {
 			locksHeld = append(locksHeld, k)
 		}
 	}
+	// sort for comparing results 
+	sort.Strings(locksHeld)
 
 	return strings.Join(locksHeld, ",")
 }

--- a/tools/checklocks/state.go
+++ b/tools/checklocks/state.go
@@ -180,11 +180,11 @@ func (l *lockState) isSubset(other *lockState) bool {
 			held++
 		}
 	}
-	return held >= l.count()
+	return held >= l.numLocksHeld()
 }
 
-// count indicates the number of locks held.
-func (l *lockState) count() int {
+// numLocksHeld indicates the number of locks held.
+func (l *lockState) numLocksHeld() int {
 	held := 0
 	for _, lockType := range l.lockedMutexes {
 		if lockType == locked {
@@ -339,7 +339,7 @@ func (l *lockState) valueAsString(v ssa.Value) string {
 
 // String returns the full lock state.
 func (l *lockState) String() string {
-	if l.count() == 0 {
+	if l.numLocksHeld() == 0 {
 		return "no locks held"
 	}
 

--- a/tools/checklocks/test/infer.go
+++ b/tools/checklocks/test/infer.go
@@ -24,7 +24,7 @@ func testGuessedAndAnnotatedValid(tc *guessedAndAnnotatedGuardStruct) {
 
 func testGuessedAndAnnotatedInvalid(tc *guessedAndAnnotatedGuardStruct) {
 	tc.guardedField = 1        // +checklocksfail
-	tc.annotatedGuardField = 2 // +checkslockfail
+	tc.annotatedGuardField = 2 // +checklocksfail
 }
 
 // TODO(jamesyou): more tests


### PR DESCRIPTION
This CL changes the implementation of tracking lock mutexes from
a slice to a map. Additionally, the set of all states a lock can
be in is now tracked through the `lockType` type.