### PR TITLE
Fix Bazel  build issue with benchlocks

### DIFF
--- a/tools/benchlocks/BUILD
+++ b/tools/benchlocks/BUILD
@@ -11,5 +11,6 @@ go_library(
         "@org_golang_x_tools//go/analysis:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/buildssa:go_default_library",
         "@org_golang_x_tools//go/ssa:go_default_library",
+        "//tools/checklocks",
     ],
 )

--- a/tools/checklocks/BUILD
+++ b/tools/checklocks/BUILD
@@ -12,7 +12,7 @@ go_library(
         "state.go",
     ],
     nogo = False,
-    visibility = ["//tools/nogo:__subpackages__"],
+    visibility = ["//tools:__subpackages__"],
     deps = [
         "@org_golang_x_tools//go/analysis:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/buildssa:go_default_library",


### PR DESCRIPTION
Quick fix for incorrect `BUILD` files stopping fresh builds.