### PR TITLE
Add support for unconditional defers

### DIFF
--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -591,12 +591,8 @@ func (pc *passContext) checkBody(fn *ssa.Function, lff *lockFunctionFacts, init 
 				entry := pre[succ]
 
 				if !entry.isCompatible(post) {
-					// TODO(jamesyou): Should we have some mechanism for +checklocksforce here?
-					pos := fn.Pos()
-					if succ.Instrs != nil {
-						pos = succ.Instrs[0].Pos()
-					}
-					pc.maybeFail(pos, "inconsistent lock states (first: %s, second: %v)", entry.String(), post.String())
+					// TODO(jamesyou): Should we simplify error reporting here?
+					pc.maybeFail(fn.Pos(), "inconsistent lock states (first: %s, second: %v)", entry.String(), post.String())
 				}
 
 				pre[succ] = entry.join(post)

--- a/tools/checklocks/state.go
+++ b/tools/checklocks/state.go
@@ -27,9 +27,8 @@ import (
 
 // lockType represents the current state of the lock.
 // The 0 value represents the unlocked state.
-// The valid states are unlocked, locked, locked & deferredunlock
-// If a state is only deferredunlock at a return site, this is considered
-// an error.
+// The valid states during analysis are:
+// unlocked, locked, deferredunlock and locked & deferredunlock
 type lockType int
 
 const (

--- a/tools/checklocks/state.go
+++ b/tools/checklocks/state.go
@@ -437,7 +437,7 @@ func (l *lockState) resolveDeferredUnlocks() (string, bool) {
 	for k, lockType := range l.mutexes {
 		if lockType.isLocked() && lockType.hasDeferredUnlock() {
 			l.modify()
-			l.mutexes[k] = unlocked
+			delete(l.mutexes, k) // k goes back to unlocked.
 		}
 	}
 

--- a/tools/checklocks/test/branches.go
+++ b/tools/checklocks/test/branches.go
@@ -39,7 +39,7 @@ func testConsistentBranching(tc *oneGuardStruct) {
 	}
 }
 
-func testInconsistentBranching(tc *oneGuardStruct) { // +checklocksfail:2
+func testInconsistentBranching(tc *oneGuardStruct) { // +checklocksfail:1
 	// We traverse the control flow graph in all consistent ways. We cannot
 	// determine however, that the first if block and second if block will
 	// evaluate to the same condition. Therefore, there are two consistent

--- a/tools/checklocks/test/defer.go
+++ b/tools/checklocks/test/defer.go
@@ -20,19 +20,8 @@ func testDeferValidUnlock(tc *oneGuardStruct) {
 	defer tc.mu.Unlock()
 }
 
-func testDeferValidAccess(tc *oneGuardStruct) {
+func testDeferValidBeforeAccess(tc *oneGuardStruct) {
 	tc.mu.Lock()
-	defer func() {
-		tc.guardedField = 1
-		tc.mu.Unlock()
-	}()
-}
-
-func testDeferInvalidAccess(tc *oneGuardStruct) {
-	tc.mu.Lock()
-	defer func() {
-		// N.B. Executed after tc.mu.Unlock().
-		tc.guardedField = 1 // +checklocksfail
-	}()
-	tc.mu.Unlock()
+	defer tc.mu.Unlock()
+	tc.guardedField = 1
 }


### PR DESCRIPTION
This CL implements a deferred unlock state for locks. These states
keep track of possible unconditional deferred unlock calls on their
respective locks. Locks states which contain mutexs with deferred
unlocks are resolved at their respective return blocks with the
ssa.RunDefer instruction.

A basic example:
```
type Counter struct {
	mu sync.Mutex
	v  int
}

func Foo(c Counter) {
	c.mu.Lock()
	defer c.mu.Unlock()
	c.v++ // ok
}
```

Existing gVisor support for path-sensitive defers is removed.